### PR TITLE
Update to non-deprecated function to fix cron job error

### DIFF
--- a/examples/external_devices_examples/live_examples/balanced_random_live_rate.py
+++ b/examples/external_devices_examples/live_examples/balanced_random_live_rate.py
@@ -78,7 +78,7 @@ def start_callback(label, connection):
 
 
 print(pop_input.label)
-poisson_control.add_start_callback(pop_input.label, start_callback)
+poisson_control.add_start_resume_callback(pop_input.label, start_callback)
 
 p.run(5000)
 


### PR DESCRIPTION
Overnight jobs picked up this error - not quite sure why the deprecated function was failing, but it seems sensible to switch to the non-deprecated version...