### PR TITLE
Use the right model name to set neurons per core

### DIFF
--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -41,6 +41,8 @@ jobs:
 
     - name: Install pip, etc
       uses: ./support/actions/python-tools
+    - name: Install matplotlib
+      uses: ./support/actions/install-matplotlib
     - name: Checkout SpiNNaker Dependencies
       uses: ./support/actions/checkout-spinn-deps
       with:
@@ -50,8 +52,6 @@ jobs:
         install: true
     - name: Setup PyNN
       uses: ./support/actions/pynn-setup
-    - name: Install matplotlib
-      uses: ./support/actions/install-matplotlib
     - name: install test requirements as no setup
       run: pip install -r requirements-test.txt
     - name: Test with pytest

--- a/examples/extra_models_examples/LGN_Izhikevich.py
+++ b/examples/extra_models_examples/LGN_Izhikevich.py
@@ -65,7 +65,7 @@ def calc_irregularity(segment):
     irregularity = 0
     isi_array = []
     for i in range(len(segment.spiketrains)):
-        if(len(segment.spiketrains[i]) > 2):
+        if len(segment.spiketrains[i]) > 2:
             isi_array.append([])
             for j in range(len(segment.spiketrains[i])-1):
                 isi_array[-1].append(

--- a/examples/synfire_if_cond_exp.py
+++ b/examples/synfire_if_cond_exp.py
@@ -23,7 +23,7 @@ import matplotlib.pyplot as plt
 runtime = 5000
 p.setup(timestep=1.0, min_delay=1.0)
 nNeurons = 200  # number of neurons in each population
-p.set_number_of_neurons_per_core(p.IF_curr_exp, nNeurons / 2)
+p.set_number_of_neurons_per_core(p.IF_cond_exp, nNeurons / 2)
 
 cell_params_lif = {'cm': 0.25,
                    'i_offset': 0.0,


### PR DESCRIPTION
The wrong model name was being used when setting the number of neurons per core in the synfire_cond example.