### PR TITLE
results from script builder

### DIFF
--- a/integration_tests/test_scripts.py
+++ b/integration_tests/test_scripts.py
@@ -51,12 +51,6 @@ class TestScripts(ScriptChecker):
     def test_examples_split_examples_va_benchmark_split(self):
         self.check_script("examples/split_examples/va_benchmark_split.py")
 
-    def test_examples_balanced_random_balanced_random(self):
-        self.check_script("examples/balanced_random/balanced_random.py")
-
-    def test_examples_balanced_random_split_balanced_random_split(self):
-        self.check_script("examples/balanced_random/split/balanced_random_split.py")
-
     def test_examples_synfire_if_curr_exp_random(self):
         self.check_script("examples/synfire_if_curr_exp_random.py")
 
@@ -185,6 +179,9 @@ class TestScripts(ScriptChecker):
 
     def test_examples_extra_models_examples_IF_cond_exp_stoc(self):
         self.check_script("examples/extra_models_examples/IF_cond_exp_stoc.py")
+
+    def test_examples_wta_example(self):
+        self.check_script("examples/wta_example.py")
 
     def test_balanced_random_balanced_random(self):
         self.check_script("balanced_random/balanced_random.py")


### PR DESCRIPTION
Integration tests run script builder before running test_scripts

This pr does the same for github

The reason examples/balanced_random tests are removed is because that duplicate code is gone!

The test_script already did
    def test_balanced_random_balanced_random(self):
        self.check_script("balanced_random/balanced_random.py")

    def test_balanced_random_split_balanced_random_split(self):
        self.check_script("balanced_random/split/balanced_random_split.py")
